### PR TITLE
Method names incorrect in generator

### DIFF
--- a/lib/generators/spree_wishlist/install/install_generator.rb
+++ b/lib/generators/spree_wishlist/install/install_generator.rb
@@ -2,11 +2,11 @@ module SpreeWishlist
   module Generators
     class InstallGenerator < Rails::Generators::Base
 
-      def add_stylesheets
+      def add_javascripts
         append_file "app/assets/javascripts/store/all.js", "//= require store/spree_wishlist\n" 
       end
 
-      def add_javascripts
+      def add_stylesheets
         inject_into_file "app/assets/stylesheets/store/all.css", " *= require store/spree_wishlist\n", :before => /\*\//, :verbose => true
       end
 


### PR DESCRIPTION
Corrected method names - add_javascripts generates javascripts, add_stylesheets generates stylesheets (Worked previously, but methods obviously named incorrectly).

Aside from that, thanks a lot for the generator template that I can base generators off for my extensions.
