### PR TITLE
Removed Override for Email Link. Style Updates

### DIFF
--- a/app/overrides/add_email_to_wishlist_footer_links.rb
+++ b/app/overrides/add_email_to_wishlist_footer_links.rb
@@ -1,7 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/wishlists/show",
-                     :name => "add_email_to_wishlist_footer_links",
-                     :insert_after => "[data-hook='wishlist_footer_links']",
-                     :text => %(<% if respond_to?(:email_to_friend_url) %> <div id="email_to_friend">
-                       <%= link_to(t('email_to_friend.send_to_friend'), email_to_friend_url('wishlist', @wishlist)) %>
-                     </div><% end %>),
-                     :disabled => false)

--- a/app/views/spree/wishlists/edit.html.erb
+++ b/app/views/spree/wishlists/edit.html.erb
@@ -1,7 +1,7 @@
-<h1><%= t(:editing_wishlist) %></h1>
+<h1 class="row"><%= t(:editing_wishlist) %></h1>
 <%= form_for @wishlist do |f| %>
   <p><%= f.label :name, t(:name) %>:&nbsp;<%= f.text_field :name %></p>
   <p><%= f.check_box :is_private %>&nbsp;<%= f.label :is_private, t(:is_private) %></p>
   <p><%= f.check_box :is_default %>&nbsp;<%= f.label :is_default, t(:is_default) %></p>
-  <%= f.submit t(:update) %> <%= t(:or) %> <%= link_to t(:delete_wishlist), @wishlist, :method => :delete, :confirm => t(:are_you_sure_wishlist) %>
+  <%= f.submit t(:update) %> <%= t(:or) %> <%= link_to t(:delete_wishlist), @wishlist, :method => :delete, :confirm => t(:are_you_sure_wishlist), :class => "button" %>
 <% end -%>

--- a/app/views/spree/wishlists/show.html.erb
+++ b/app/views/spree/wishlists/show.html.erb
@@ -1,8 +1,8 @@
-<div id="wishlist_header">
+<div id="wishlist_header" class="row">
   <h1><%= @wishlist.name %></h1>
   <% if @wishlist.user == current_user %>
     <div id="manage_wishlist_links">
-      <%= link_to t(:edit_wishlist), edit_wishlist_path(@wishlist) %>
+      <%= link_to t(:edit_wishlist), edit_wishlist_path(@wishlist), :class => 'button' %>
     </div>
     <div><%= render :partial => 'accessibility' %></div>
   <% end -%>
@@ -28,10 +28,10 @@
     <tr class="<%= cycle('', 'alt') %>">
     <% if @wishlist.user == current_user %>
       <td>
-        <%= link_to t(:remove_from_wishlist), wish, :method => :delete %>
+        <p><%= link_to t(:remove_from_wishlist), wish, :method => :delete, :class => 'button' %></p>
         <%= form_for :order, :url => populate_orders_url do |f| %>
           <%= hidden_field_tag "variants[#{variant.id}]", 1, :size => 3 %>
-          <%= link_to t(:add_to_cart), '#', :onclick => "$(this).parent().submit(); return false;" %>
+          <%= link_to t(:add_to_cart), '#', :onclick => "$(this).parent().submit(); return false;", :class => "button" %>
         <% end %>
         <% if current_user.wishlists.count > 1 %>
           <%= t(:move_to_another_wishlist) %>:
@@ -59,7 +59,7 @@
         <%= variant.in_stock? ? t(:in_stock) : t(:out_of_stock) %>
       </td>
       <td>
-        <%= wish.created_at %>
+        <%= wish.created_at.strftime "%m/%d/%Y" %>
       </td>
       <td>
         <%= number_to_currency(variant.price) %>
@@ -75,7 +75,10 @@
 </table>
 <div class="footer_links" data-hook="wishlist_footer_links">
 <% if @wishlist.user == current_user %>
-  <%= link_to t(:create_new_wishlist), new_wishlist_path %>
+  <%= link_to t(:create_new_wishlist), new_wishlist_path, :class => "button" %>
 <% end -%>
-<%= link_to t(:continue_shopping), products_path %>
+<%= link_to t(:continue_shopping), products_path, :class => "button" %>
+<% if respond_to?(:email_to_friend_url) %>
+  <%= link_to t('email_to_friend.send_to_friend'), email_to_friend_url('wishlist', @wishlist), :class => "button" %>
+<% end %>
 </div>


### PR DESCRIPTION
- Added :class => 'button' to all action links
- m/d/y on create_at header. The full timestamp seemed a bit ugly and unneeded for a wishlist
- Added some skeleton CSS classes here and there
- Eliminated override for email_to_wishlist; added directly to wishlist/show instead
