### PR TITLE
Make spree_wishlist work with spree 1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ end
 
 # Specify your dependencies in spree_wishlist.gemspec
 gemspec
+
+gem 'spree_auth_devise', :git => "git://github.com/spree/spree_auth_devise"

--- a/lib/spree_wishlist.rb
+++ b/lib/spree_wishlist.rb
@@ -1,3 +1,3 @@
 require 'spree_core'
-require 'spree_auth'
+require 'spree_auth_devise'
 require 'spree_wishlist/engine'

--- a/spree_wishlist.gemspec
+++ b/spree_wishlist.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'spree_core', '>= 1.1.0'
-  s.add_dependency 'spree_auth', '>= 1.1.0'
+  s.add_dependency 'spree_core', '>= 1.2.0'
 
   s.add_development_dependency 'factory_girl', '2.6.4'
   s.add_development_dependency 'rspec-rails',  '~> 2.9.0'


### PR DESCRIPTION
According to the spree  [issue #1512](https://github.com/spree/spree/pull/1512) that removed authentication module to a external gem spree_auth_devise on spree 1.2. I've updated spree_wishlist to respond to this changes.
