### PR TITLE
Fixed accidental search/replace

### DIFF
--- a/app/views/spree/wishlists/show.html.erb
+++ b/app/views/spree/wishlists/show.html.erb
@@ -31,7 +31,7 @@
         <p><%= link_to Spree.t(:remove_from_wishlist), wish, :method => :delete, :class => 'button' %></p>
         <%= form_for :order, :url => populate_orders_url do |f| %>
           <%= hidden_field_tag "variants[#{variant.id}]", 1, :size => 3 %>
-          <%= link_to Spree.t(:add_to_cart), '#', :onclick => "$(this).parenSpree.t().submiSpree.t(); return false;", :class => "button" %>
+          <%= link_to Spree.t(:add_to_cart), '#', :onclick => "$(this).parent().submit(); return false;", :class => "button" %>
         <% end %>
         <% if spree_current_user.wishlists.count > 1 %>
           <%= Spree.t(:move_to_another_wishlist) %>:


### PR DESCRIPTION
The `Spree.t()` replacement on this files seems to have accidentally broken the add to cart javascript.
