### PR TITLE
adding :original to override

### DIFF
--- a/app/overrides/add_wishlists_to_account_my_orders.rb
+++ b/app/overrides/add_wishlists_to_account_my_orders.rb
@@ -2,4 +2,5 @@ Deface::Override.new(:virtual_path => "spree/users/show",
                      :name => "add_wishlists_to_account_my_orders",
                      :insert_after => "[data-hook='account_my_orders']",
                      :partial => "spree/users/wishlists",
-                     :disabled => false)
+                     :disabled => false,
+                     :original => "f1f0e9b7901295ea2f4dedaa53efd632aaa2d26e")


### PR DESCRIPTION
As per warning:

```
Deface: [WARNING] No :original defined for 'add_wishlists_to_account_my_orders', you should change its definition to include:
 :original => 'f1f0e9b7901295ea2f4dedaa53efd632aaa2d26e'
```
