### PR TITLE
using indices to accelerate load of user wishlists

### DIFF
--- a/db/migrate/20140422003308_add_index_to_wishlists.rb
+++ b/db/migrate/20140422003308_add_index_to_wishlists.rb
@@ -1,0 +1,6 @@
+class AddIndexToWishlists < ActiveRecord::Migration
+  def change
+    add_index :spree_wishlists, [:user_id]
+    add_index :spree_wishlists, [:user_id, :is_default]
+  end
+end


### PR DESCRIPTION
Using indices successfully reduced `Spree::User#wishlist` from a 21.7ms operation in my app to a 0.8ms operation.

As this method is run by default with every pageview, and is not cached by default, the performance savings adds up.
