### PR TITLE
[2-1-stable] avoid orphaning wished_products if wishlists are destroyed

### DIFF
--- a/app/models/spree/wishlist.rb
+++ b/app/models/spree/wishlist.rb
@@ -1,6 +1,6 @@
 class Spree::Wishlist < ActiveRecord::Base
   belongs_to :user, :class_name => Spree.user_class
-  has_many :wished_products
+  has_many :wished_products, dependent: :destroy
   before_create :set_access_hash
 
   validates :name, :presence => true

--- a/spec/models/spree/wishlist_spec.rb
+++ b/spec/models/spree/wishlist_spec.rb
@@ -74,4 +74,19 @@ describe Spree::Wishlist do
     end
   end
 
+  context '#destroy' do
+    before(:each) do
+      @variant = FactoryGirl.create(:variant)
+      wished_product = Spree::WishedProduct.new(:variant => @variant)
+      @wishlist.wished_products << wished_product
+      @wishlist.save
+    end
+
+    it 'deletes associated wished products' do
+      expect {
+        @wishlist.destroy
+      }.to change(Spree::WishedProduct, :count).by(-1)
+    end
+  end
+
 end


### PR DESCRIPTION
If a wishlist is destroyed the wished_product records are orphaned.  This ensures they are properly removed along with the wishlist
