### PR TITLE
avoid orphaning wished_products if wishlists are destroyed

### DIFF
--- a/app/models/spree/wishlist.rb
+++ b/app/models/spree/wishlist.rb
@@ -1,6 +1,6 @@
 class Spree::Wishlist < ActiveRecord::Base
   belongs_to :user, :class_name => Spree.user_class
-  has_many :wished_products
+  has_many :wished_products, dependent: :destroy
   before_create :set_access_hash
 
   validates :name, :presence => true

--- a/spec/models/spree/wishlist_spec.rb
+++ b/spec/models/spree/wishlist_spec.rb
@@ -79,4 +79,15 @@ describe Spree::Wishlist do
       expect(wishlist.is_public?).not_to be true
     end
   end
+
+  context '#destroy' do
+    let!(:wished_product) { create(:wished_product) }
+
+    it 'deletes associated wished products' do
+      expect {
+        wished_product.wishlist.destroy
+      }.to change(Spree::WishedProduct, :count).by(-1)
+    end
+
+  end
 end


### PR DESCRIPTION
If a wishlist is destroyed the wished_product records are orphaned. This ensures they are properly removed along with the wishlist
