### PR TITLE
Remove class="row" header since there is no grid inside

### DIFF
--- a/app/views/spree/wishlists/show.html.erb
+++ b/app/views/spree/wishlists/show.html.erb
@@ -1,4 +1,4 @@
-<div id="wishlist_header" class="row">
+<div id="wishlist_header">
   <h1><%= @wishlist.name %></h1>
   <% if @wishlist.user == spree_current_user %>
     <div id="manage_wishlist_links">


### PR DESCRIPTION
There's no col-*-* elements inside header, so the row class just keeps inner elements in a -15px wrong padding, making the view unaligned.