### PR TITLE
Rename Spree::WishedProduct => Spree::WishedVariant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree'
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-1-stable'
 
 gemspec

--- a/app/assets/javascripts/spree/frontend/wishlist.js.coffee
+++ b/app/assets/javascripts/spree/frontend/wishlist.js.coffee
@@ -1,10 +1,10 @@
 Spree.ready ($) ->
-  $('#new_wished_product').on 'submit', ->
+  $('#new_wished_variant').on 'submit', ->
     selected_variant_id = $('#product-variants input[type=radio]:checked').val()
-    $('#wished_product_variant_id').val selected_variant_id if selected_variant_id
+    $('#wished_variant_variant_id').val selected_variant_id if selected_variant_id
 
     cart_quantity = $('.add-to-cart #quantity').val()
-    $('#wished_product_quantity').val cart_quantity if cart_quantity
+    $('#wished_variant_quantity').val cart_quantity if cart_quantity
 
   $('form#change_wishlist_accessibility').on 'submit', ->
     $.post $(this).prop('action'), $(this).serialize(), null, 'script'

--- a/app/controllers/spree/wished_variants_controller.rb
+++ b/app/controllers/spree/wished_variants_controller.rb
@@ -1,0 +1,43 @@
+class Spree::WishedVariantsController < Spree::StoreController
+  respond_to :html
+
+  def create
+    @wished_variant = Spree::WishedVariant.new(wished_variant_attributes)
+    @wishlist = spree_current_user.wishlist
+
+    if @wishlist.include? params[:wished_variant][:variant_id]
+      @wished_variant = @wishlist.wished_variants.detect { |wp| wp.variant_id == params[:wished_variant][:variant_id].to_i }
+    else
+      @wished_variant.wishlist = spree_current_user.wishlist
+      @wished_variant.save
+    end
+
+    respond_with(@wished_variant) do |format|
+      format.html { redirect_to wishlist_url(@wishlist) }
+    end
+  end
+
+  def update
+    @wished_variant = Spree::WishedVariant.find(params[:id])
+    @wished_variant.update_attributes(wished_variant_attributes)
+
+    respond_with(@wished_variant) do |format|
+      format.html { redirect_to wishlist_url(@wished_variant.wishlist) }
+    end
+  end
+
+  def destroy
+    @wished_variant = Spree::WishedVariant.find(params[:id])
+    @wished_variant.destroy
+
+    respond_with(@wished_variant) do |format|
+      format.html { redirect_to wishlist_url(@wished_variant.wishlist) }
+    end
+  end
+
+  private
+
+  def wished_variant_attributes
+    params.require(:wished_variant).permit(:variant_id, :wishlist_id, :remark, :quantity)
+  end
+end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,3 +1,3 @@
 Spree::Variant.class_eval do
-  has_many :wished_products, dependent: :destroy
+  has_many :wished_variants, dependent: :destroy
 end

--- a/app/models/spree/wished_variant.rb
+++ b/app/models/spree/wished_variant.rb
@@ -1,0 +1,13 @@
+class Spree::WishedVariant < ActiveRecord::Base
+  belongs_to :variant
+  belongs_to :wishlist
+
+  def total
+    quantity * variant.price
+  end
+
+  def display_total
+    Spree::Money.new(total)
+  end
+
+end

--- a/app/models/spree/wishlist.rb
+++ b/app/models/spree/wishlist.rb
@@ -1,12 +1,12 @@
 class Spree::Wishlist < ActiveRecord::Base
   belongs_to :user, class_name: Spree.user_class
-  has_many :wished_products, dependent: :destroy
+  has_many :wished_variants, dependent: :destroy
   before_create :set_access_hash
 
   validates :name, presence: true
 
   def include?(variant_id)
-    wished_products.map(&:variant_id).include? variant_id.to_i
+    wished_variants.map(&:variant_id).include? variant_id.to_i
   end
 
   def to_param

--- a/app/views/spree/products/_wishlist_form.html.erb
+++ b/app/views/spree/products/_wishlist_form.html.erb
@@ -1,6 +1,6 @@
 <% if spree_current_user %>
   <div id="wishlist-form">
-    <%= form_for Spree::WishedProduct.new do |f| %>
+    <%= form_for Spree::WishedVariant.new do |f| %>
       <%= f.hidden_field :variant_id, value: @product.master.id %>
       <%= f.hidden_field :quantity %>
       <button type="submit" class="btn btn-info">

--- a/app/views/spree/wishlists/show.html.erb
+++ b/app/views/spree/wishlists/show.html.erb
@@ -23,8 +23,8 @@
     </tr>
   </thead>
   <tbody id="line_items">
-  <% if @wishlist.wished_products.size > 0 %>
-    <% @wishlist.wished_products.each do |wish|
+  <% if @wishlist.wished_variants.size > 0 %>
+    <% @wishlist.wished_variants.each do |wish|
         variant = wish.variant
         product = variant.product %>
     <tr class="<%= cycle('', 'alt') %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.add_routes do
   resources :wishlists
-  resources :wished_products, only: [:create, :update, :destroy]
+  resources :wished_variants, only: [:create, :update, :destroy]
   get '/wishlist' => 'wishlists#default', as: 'default_wishlist'
 end

--- a/db/migrate/20140403013413_remove_wished_products_for_deleted_variants.rb
+++ b/db/migrate/20140403013413_remove_wished_products_for_deleted_variants.rb
@@ -1,7 +1,9 @@
 class RemoveWishedProductsForDeletedVariants < ActiveRecord::Migration
   def up
-    Spree::WishedProduct.includes(:variant).find_each do |wished_product|
-      wished_product.destroy unless wished_product.variant
+    if Object.const_defined?('Spree::WishedProduct')
+      Spree::WishedProduct.includes(:variant).find_each do |wished_product|
+        wished_product.destroy unless wished_product.variant
+      end
     end
   end
 

--- a/db/migrate/20160429130606_rename_spree_wished_products_to_spree_wished_variants.rb
+++ b/db/migrate/20160429130606_rename_spree_wished_products_to_spree_wished_variants.rb
@@ -1,0 +1,9 @@
+class RenameSpreeWishedProductsToSpreeWishedVariants < ActiveRecord::Migration
+  def up
+    rename_table :spree_wished_products, :spree_wished_variants
+  end
+
+  def down
+    rename_table :spree_wished_variants, :spree_wished_products
+  end
+end

--- a/db/migrate/20160429130617_remove_wished_variants_for_deleted_variants.rb
+++ b/db/migrate/20160429130617_remove_wished_variants_for_deleted_variants.rb
@@ -1,0 +1,12 @@
+class RemoveWishedVariantsForDeletedVariants < ActiveRecord::Migration
+  def up
+    if Object.const_defined?('Spree::WishedVariant')
+      Spree::WishedVariant.includes(:variant).find_each do |wished_variant|
+        wished_variant.destroy unless wished_variant.variant
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/lib/wishlist_ability.rb
+++ b/lib/wishlist_ability.rb
@@ -15,7 +15,7 @@ class WishlistAbility
     end
 
     # Anyone can add wished product to wishlist
-    can :create, Spree::WishedProduct do
+    can :create, Spree::WishedVariant do
       !user.new_record?
     end
 
@@ -30,12 +30,12 @@ class WishlistAbility
     end
 
     # You can only view own wishlist product unless wishlist public
-    can :read, Spree::WishedProduct do |wished_product|
+    can :read, Spree::WishedVariant do |wished_product|
       wished_product.wishlist.user == user || wished_product.wishlist.is_public?
     end
 
     # You can only browse or change own wishlist product
-    can [:index, :update, :destroy], Spree::WishedProduct do |wished_product|
+    can [:index, :update, :destroy], Spree::WishedVariant do |wished_product|
       wished_product.wishlist.user == user
     end
   end

--- a/spec/controllers/spree/wished_variants_controller_spec.rb
+++ b/spec/controllers/spree/wished_variants_controller_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe Spree::WishedVariantsController, type: :controller do
+  let(:user)           { create(:user) }
+  let!(:wished_variant) { create(:wished_variant) }
+  let(:attributes)     { attributes_for(:wished_variant) }
+
+  before { allow(controller).to receive(:spree_current_user).and_return(user) }
+
+  context '#create' do
+    context 'with valid params' do
+      it 'creates a new Spree::WishedVariant' do
+        expect {
+          spree_post :create, wished_variant: attributes
+        }.to change(Spree::WishedVariant, :count).by(1)
+      end
+
+      it 'assigns a newly created wished_variant as @wished_variant' do
+        spree_post :create, wished_variant: attributes
+        expect(assigns(:wished_variant)).to be_a Spree::WishedVariant
+        expect(assigns(:wished_variant)).to be_persisted
+      end
+
+      it 'redirects to the created wished_variant' do
+        spree_post :create, wished_variant: attributes
+        expect(response).to redirect_to spree.wishlist_path(Spree::WishedVariant.last.wishlist)
+      end
+
+      it 'does not save if wished product already exist in wishlist' do
+        variant  = create(:variant)
+        wishlist = create(:wishlist, user: user)
+        wished_variant = create(:wished_variant, wishlist: wishlist, variant: variant)
+        expect {
+          spree_post :create, id: wished_variant.id, wished_variant: { wishlist_id: wishlist.id, variant_id: variant.id }
+        }.to change(Spree::WishedVariant, :count).by(0)
+      end
+    end
+
+    context 'with invalid params' do
+      it 'raises error' do
+        expect { spree_post :create }.to raise_error
+      end
+    end
+  end
+
+  context '#update' do
+    context 'with valid params' do
+      it 'assigns the requested wished_variant as @wished_variant' do
+        spree_put :update, id: wished_variant, wished_variant: attributes
+        expect(assigns(:wished_variant)).to eq wished_variant
+      end
+
+      it 'redirects to the wished_variant' do
+        spree_put :update, id: wished_variant, wished_variant: attributes
+        expect(response).to redirect_to spree.wishlist_path(wished_variant.wishlist)
+      end
+    end
+
+    context 'with invalid params' do
+      it 'raises error' do
+        expect { spree_put :update }.to raise_error
+      end
+    end
+  end
+
+  context '#destroy' do
+    it 'destroys the requested wished_variant' do
+      expect {
+        spree_delete :destroy, id: wished_variant
+      }.to change(Spree::WishedVariant, :count).by(-1)
+    end
+
+    it 'redirects to the wished_variants list' do
+      spree_delete :destroy, id: wished_variant
+      expect(response).to redirect_to spree.wishlist_path(wished_variant.wishlist)
+    end
+
+    it 'requires the :id parameter' do
+      expect { spree_delete :destroy }.to raise_error
+    end
+  end
+end

--- a/spec/factories/wished_variant_factory.rb
+++ b/spec/factories/wished_variant_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :wished_variant, class: Spree::WishedVariant do
+    variant
+    wishlist
+    remark 'Some remark..'
+  end
+end

--- a/spec/features/spree/wished_variant_spec.rb
+++ b/spec/features/spree/wished_variant_spec.rb
@@ -1,0 +1,99 @@
+RSpec.feature 'Wished Variant', :js do
+  given(:user) { create(:user) }
+
+  context 'add' do
+    given(:product) { create(:product) }
+
+    background do
+      sign_in_as! user
+    end
+
+    scenario 'when user has a default wishlist' do
+      wishlist = create(:wishlist, is_default: true, user: user)
+
+      add_to_wishlist product
+
+      expect(page).to have_content wishlist.name
+      expect(page).to have_content product.name
+    end
+
+    scenario 'when user has no default but with non-default wishlist' do
+      wishlist = create(:wishlist, is_default: false, user: user)
+
+      add_to_wishlist product
+
+      expect(wishlist.reload.is_default).to be true
+      expect(page).to have_content wishlist.name
+      expect(page).to have_content product.name
+    end
+
+    scenario 'when user has no wishlist at all' do
+      expect(user.wishlists).to be_empty
+
+      add_to_wishlist product
+
+      expect(user.wishlists.reload.count).to eq(1)
+      expect(page).to have_content user.wishlists.first.name
+      expect(page).to have_content product.name
+    end
+
+    scenario 'when user chooses different quantity of item' do
+      wishlist = create(:wishlist, user: user)
+
+      visit spree.product_path(product)
+      fill_in "quantity", with: "15"
+      click_button 'Add to wishlist'
+
+      expect(page).to have_content product.name
+      expect(page).to have_selector("input[value='15']")
+    end
+  end
+
+  context 'delete' do
+    given(:wishlist) { create(:wishlist, user: user) }
+
+    background do
+      sign_in_as! user
+    end
+
+    scenario 'from a wishlist with one wished product' do
+      wished_variant = create(:wished_variant, wishlist: wishlist)
+
+      visit spree.wishlist_path(wishlist)
+
+      wp_path = spree.wished_variant_path(wished_variant)
+      delete_links = find(:xpath, '//table[@id="wishlist"]/tbody').all(:xpath, './/tr/td/p/a')
+      delete_link = delete_links.select { |link| link[:href] == wp_path }.first
+      delete_link.click
+
+      expect(page).not_to have_content wished_variant.variant.product.name
+    end
+
+    scenario 'randomly from a wishlist with multiple wished products while maintaining ordering by date added' do
+      wished_variants = [
+        create(:wished_variant, wishlist: wishlist),
+        create(:wished_variant, wishlist: wishlist),
+        create(:wished_variant, wishlist: wishlist)
+      ]
+      wished_variant = wished_variants.delete_at(Random.rand(wished_variants.length))
+
+      visit spree.wishlist_path(wishlist)
+
+      wp_path = spree.wished_variant_path(wished_variant)
+      delete_links = find(:xpath, '//table[@id="wishlist"]/tbody').all(:xpath, './/tr/td/p/a')
+      delete_link = delete_links.select { |link| link[:href] == wp_path }.first
+      delete_link.click
+      pattern = Regexp.new(wished_variants.map { |wp| wp.variant.product.name }.join('.*'))
+
+      expect(page).not_to have_content wished_variant.variant.product.name
+      expect(page).to have_content pattern
+    end
+  end
+
+  private
+
+  def add_to_wishlist(product)
+    visit spree.product_path(product)
+    click_button 'Add to wishlist'
+  end
+end

--- a/spec/lib/wishlist_ability_spec.rb
+++ b/spec/lib/wishlist_ability_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe WishlistAbility do
   context 'for Wished Product' do
     let(:resource) do
       create(
-        :wished_product,
+        :wished_variant,
         wishlist: create(:wishlist, user: user),
         variant:  create(:variant)
       )

--- a/spec/models/spree/wished_variant_spec.rb
+++ b/spec/models/spree/wished_variant_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Spree::WishedVariant, type: :model do
+
+  it { is_expected.to belong_to(:variant) }
+  it { is_expected.to belong_to(:wishlist) }
+
+  it 'has a valid factory' do
+    expect(build(:wished_variant)).to be_valid
+  end
+
+  describe '#quantity' do
+    subject { build(:wished_variant) }
+
+    it { is_expected.to respond_to(:quantity) }
+    it { expect(subject.quantity).to eq(1) }
+  end
+end

--- a/spec/models/spree/wishlist_spec.rb
+++ b/spec/models/spree/wishlist_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Spree::Wishlist, type: :model do
   let(:wishlist) { create(:wishlist, user: user, name: 'My Wishlist') }
 
   it { is_expected.to belong_to(:user) }
-  it { is_expected.to have_many(:wished_products) }
+  it { is_expected.to have_many(:wished_variants) }
   it { is_expected.to validate_presence_of(:name) }
 
   it 'has a valid factory' do
@@ -14,8 +14,8 @@ RSpec.describe Spree::Wishlist, type: :model do
     let(:variant) { create(:variant) }
 
     before do
-      wished_product = create(:wished_product, variant: variant)
-      wishlist.wished_products << wished_product
+      wished_variant = create(:wished_variant, variant: variant)
+      wishlist.wished_variants << wished_variant
       wishlist.save
     end
 
@@ -79,12 +79,12 @@ RSpec.describe Spree::Wishlist, type: :model do
   end
 
   context '#destroy' do
-    let!(:wished_product) { create(:wished_product) }
+    let!(:wished_variant) { create(:wished_variant) }
 
     it 'deletes associated wished products' do
       expect {
-        wished_product.wishlist.destroy
-      }.to change(Spree::WishedProduct, :count).by(-1)
+        wished_variant.wishlist.destroy
+      }.to change(Spree::WishedVariant, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
Spree::WishedProduct is a model associated to variant and wishlist.

So, it should be rename as Spree::WishedVariant.
